### PR TITLE
Avoid ldd on Linux by using custom script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-result
+result/
+__pycache__
+.mypy_cache

--- a/bundle-linux.sh
+++ b/bundle-linux.sh
@@ -9,6 +9,10 @@ exe_dir="exe"
 bin_dir="bin"
 lib_dir="lib"
 
+printNeeded() {
+  print-needed-elf "$1" | grep '/nix/store/'
+}
+
 bundleLib() {
   local file="$1"
   local install_dir="$out/$lib_dir"
@@ -43,7 +47,7 @@ bundleLib() {
   echo "Bundling $real_file to $install_dir"
 
   local linked_libs
-  linked_libs=$(ldd "$real_file" 2>/dev/null | grep -Eo '/nix/store/[^(=]+' || true)
+  linked_libs=$(printNeeded "$real_file" || true)
   for linked_lib in $linked_libs; do
     bundleLib "$linked_lib" "lib"
   done
@@ -73,7 +77,7 @@ bundleExe() {
   bundleLib "$interpreter" "lib"
 
   local linked_libs
-  linked_libs=$(ldd "$exe" 2>/dev/null | grep -Eo '/nix/store/[^(=]+' || true)
+  linked_libs=$(printNeeded "$exe" || true)
   for linked_lib in $linked_libs; do
     bundleLib "$linked_lib" "lib"
   done

--- a/bundle-macos.sh
+++ b/bundle-macos.sh
@@ -10,6 +10,10 @@ dylib_dir="Frameworks/Library.dylib"
 
 mkdir -p "$out/$bin_dir" "$out/$dylib_dir"
 
+printNeeded() {
+  otool -L "$real_file" | tail -n +2 | grep '/nix/store/' | cut -d '(' -f -1
+}
+
 bundleBin() {
   local file="$1"
   local file_type="$2"
@@ -34,7 +38,7 @@ bundleBin() {
   chmod +w "$copied_file"
 
   local linked_libs
-  linked_libs=$(otool -L "$real_file" | tail -n +2 | grep '/nix/store/' | cut -d '(' -f -1 || true)
+  linked_libs=$(printNeeded "$real_file" || true)
   for linked_lib in $linked_libs; do
     local real_lib
     real_lib=$(realpath "$linked_lib")

--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,10 @@ path: # May be:
       #  2) a path to a directory containing bin/, or
       #  3) a path to an executable.
 let
+  print-needed-elf = pkgs.writeScriptBin
+    "print-needed-elf"
+    '''${pkgs.python3}'/bin/python ${./print_needed_elf.py} "$@"'';
+
   cfg =
     if pkgs.stdenv.isDarwin then
       {
@@ -12,7 +16,7 @@ let
       }
     else if pkgs.stdenv.isLinux then
       {
-        deps = [pkgs.glibc];
+        deps = [pkgs.glibc print-needed-elf];
         script = "bash ${./bundle-linux.sh}";
       }
     else

--- a/print_needed_elf.py
+++ b/print_needed_elf.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# Prints resolved paths to needed libraries for an ELF executable.
+# ldd also does this, but it segfaults in some odd scenarios so we avoid it.
+import sys
+import os
+import subprocess
+from typing import Any, Iterable, List
+
+def eprint(msg: Any):
+  print(msg, file=sys.stderr)
+
+def run(args: List[str]) -> str:
+  result = subprocess.run(args, capture_output=True)
+  if result.returncode != 0:
+    eprint(result.stderr)
+    eprint("Command failed with return code {}: {}".format(result.returncode, args))
+    sys.exit(result.returncode)
+  return result.stdout.decode("utf-8")
+
+def stripped_strs(strs: Iterable[str]) -> Iterable[str]:
+  return (cleaned for x in strs for cleaned in [x.strip()] if cleaned != "")
+
+def get_rpaths(exe: str) -> Iterable[str]:
+  return stripped_strs(run(["patchelf", "--print-rpath", exe]).split(":"))
+
+def resolve_origin(origin: str, paths: Iterable[str]) -> Iterable[str]:
+  return (path.replace("$ORIGIN", origin) for path in paths)
+
+def get_needed(exe: str) -> Iterable[str]:
+  return stripped_strs(run(["patchelf", "--print-needed", exe]).splitlines())
+
+def resolve_paths(needed: Iterable[str], rpaths: List[str]) -> Iterable[str]:
+  existing_paths = lambda lib, paths: (
+    abs_path for path in paths for abs_path in [os.path.join(path, lib)]
+    if os.path.exists(abs_path)
+  )
+  return (
+    found if found is not None else eprint("Warning: can't find {} in {}".format(lib, rpaths))
+    for lib in needed for found in [next(existing_paths(lib, rpaths), None)]
+  )
+
+def main(exe: str):
+  dirname = os.path.dirname(exe)
+  rpaths_raw = list(get_rpaths(exe))
+  rpaths_raw = [dirname] if rpaths_raw == [] else rpaths_raw
+  rpaths = list(resolve_origin(dirname, rpaths_raw))
+  for path in (x for x in resolve_paths(get_needed(exe), rpaths) if x is not None):
+    print(path)
+
+if __name__ == "__main__":
+  main(*sys.argv[1:])


### PR DESCRIPTION
ldd segfaults when run from an amd64 docker container on M1 macOS. This makes it impossible to build a bundle for amd64 on macOS. This change uses a custom python script wrapping patchelf to produce the same output needed from ldd.

Fixes #6 