### PR TITLE
Linux only: Invoke the interpreter directly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: "Test"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-build -E 'with import <nixpkgs> {}; callPackage ./. {} gzip'
+    - run: result/bin/gzip README.md
+    - run: test -f README.md.gz

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This is a simple [Nix](https://nixos.org/) derivation to bundle Mach-O (macOS) a
 
 If you are able to build your executable with full static linking, that would be better than using this derivation. For cases where that is too difficult, you can use this.
 
-**NOTE: Linux support is still a work in progress. Bundles may not work on all targets systems, particularly those where `/tmp` is mounted with `noexec`.**
-
 This tool has a very similar goal to [nix-bundle](https://github.com/matthewbauer/nix-bundle) with some key differences:
 
   1. `nix-bundle` works on arbitrary derivations and can bundle any resource, not just shared libraries. This tool only works on executables and their shared libraries.

--- a/bundle-linux.sh
+++ b/bundle-linux.sh
@@ -62,17 +62,11 @@ bundleExe() {
   local interpreter="$2"
   local exe_name
   exe_name=$(basename "$exe")
-  local real_interpreter
-  real_interpreter=$(realpath "$interpreter")
-  local interpreter_checksum
-  interpreter_checksum=$(sha256sum "$real_interpreter" | cut -d' ' -f1)
-  local interpreter_install_path
-  interpreter_install_path="/tmp/$interpreter_checksum-$(basename "$real_interpreter")"
 
   local copied_exe="$out/$exe_dir/$exe_name"
   cp "$exe" "$copied_exe"
   chmod +w "$copied_exe"
-  patchelf --set-interpreter "$interpreter_install_path" --set-rpath "\$ORIGIN/../$lib_dir" "$copied_exe"
+  patchelf --set-interpreter "$(basename "interpreter")" --set-rpath "\$ORIGIN/../$lib_dir" "$copied_exe"
 
   bundleLib "$interpreter" "lib"
 
@@ -85,15 +79,8 @@ bundleExe() {
   printf '#!/bin/sh
 set -eu
 dir="$(cd -- "$(dirname "$(dirname "$0")")" >/dev/null 2>&1 ; pwd -P)"
-if [ ! -f %s ]; then
-  cp "$dir"/%s %s
-  chmod 555 %s
-fi
-exec "$dir"/%s "$@"' \
-  "'$interpreter_install_path'" \
+exec "$dir"/%s "$dir"/%s "$@"' \
   "'$lib_dir/$(basename "$interpreter")'" \
-  "'$interpreter_install_path'" \
-  "'$interpreter_install_path'" \
   "'$exe_dir/$exe_name'" \
   > "$out/$bin_dir/$exe_name"
   chmod +x "$out/$bin_dir/$exe_name"


### PR DESCRIPTION
This avoids using `/tmp` which might have been mounted with `noexec`.

Fixes #10

This might cause *other* issues, however. I haven't tested it much.