### PR TITLE
delete the empty directories to keep the bundle cleaner

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,4 +36,5 @@ pkgs.runCommand "bundle-${name}"
     '' else ''
       ${cfg.script} "$out" ${pkgs.lib.escapeShellArg path}
     ''}
+    find $out -empty -type d -delete
   ''


### PR DESCRIPTION
in case there's no runtime dependencies at all, which could happen on macos.