### PR TITLE
Never force `path` during evaluation phase

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,10 +39,10 @@ pkgs.runCommand "bundle-${name}"
     export bin_dir='${bin_dir}'
     export exe_dir='${exe_dir}'
     export lib_dir='${lib_dir}'
-    ${if builtins.pathExists "${path}/bin" then ''
+    if [ -d "${path}/bin" ]; then
       find '${path}/bin' -type f -executable -print0 | xargs -0 --max-args 1 ${cfg.script} "$out"
-    '' else ''
+    else
       ${cfg.script} "$out" ${pkgs.lib.escapeShellArg path}
-    ''}
+    fi
     find $out -empty -type d -delete
   ''

--- a/default.nix
+++ b/default.nix
@@ -27,10 +27,8 @@ let
     else
       throw "Unsupported platform: only darwin and linux are supported";
 
-  name = if pkgs.lib.isDerivation path then path.name else builtins.baseNameOf path;
-  overrideEnv = name: value: if value == null then "" else "export ${name}='${value}'";
 in
-pkgs.runCommand "bundle-${name}"
+pkgs.runCommand "bundle"
   {
     nativeBuildInputs = cfg.deps ++ [ pkgs.nukeReferences ];
   }

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ pkgs.runCommand "bundle"
     export bin_dir='${bin_dir}'
     export exe_dir='${exe_dir}'
     export lib_dir='${lib_dir}'
-    if [ -d "${path}/bin" ]; then
+    if [[ -d "${path}/bin" ]]; then
       find '${path}/bin' -type f -executable -print0 | xargs -0 --max-args 1 ${cfg.script} "$out"
     else
       ${cfg.script} "$out" ${pkgs.lib.escapeShellArg path}


### PR DESCRIPTION
`builtins.baseNameOf` and `builtins.pathExists` requires the derivation that provides `path` in its output to be built during evaluation phase. We have a `x86_64-linux` Hydra server with a MacOS machine as a remote builder. We evaluate all derivations on the main Hydra server, only distributing the actual building to MacOS. `builtins.pathExists` caused the entire build process of MacOS derivations to run during evaluation. Those heavy work won't show as normal Hydra jobs, and the failures are shown in "Evaluation Error" tab.